### PR TITLE
Removing Pac* stuff for now.

### DIFF
--- a/conky/conky.conf
+++ b/conky/conky.conf
@@ -48,8 +48,8 @@ Kernel $alignr $kernel
 Uptime $alignr $uptime
 Temperature $alignr ${acpitemp}°C
 Battery $alignr ${battery_percent BAT1}%
-Pacman $alignr ${execpi 300 checkupdates | wc -l}
-Pacaur $alignr ${execpi 900 pacaur -k | wc -l}
+#Pacman $alignr ${execpi 300 checkupdates | wc -l}
+#Pacaur $alignr ${execpi 900 pacaur -k | wc -l}
 
 # CPU
 ${template0 CPU}


### PR DESCRIPTION
### Description

Removing the Pac{man, aur} update checkers for now. They seem to be holding up the launch of Conky itself... Don't know if it's because of slow internet or the time between checks.